### PR TITLE
allow parameters with container.kill()

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -923,7 +923,7 @@ var Container = function () {
 
 
       var call = {
-        path: '/containers/' + id + '/kill',
+        path: '/containers/' + id + '/kill?',
         method: 'POST',
         options: opts,
         statusCodes: {

--- a/src/container.js
+++ b/src/container.js
@@ -680,7 +680,7 @@ class Container {
     [ opts, id ] = this.__processArguments(opts, id)
 
     const call = {
-      path: `/containers/${id}/kill`,
+      path: `/containers/${id}/kill?`,
       method: 'POST',
       options: opts,
       statusCodes: {


### PR DESCRIPTION
I was needing to use the kill command with the query parameter {signal:"HUP"}, but the query parameters in opts were not being forwarded over.  This seems to make it work, though I'm not certain if I did it right.  Let me know.

And thanks for making this available.  It has been really helpful.