### PR TITLE
Allow non streaming call to container.stats

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -444,7 +444,7 @@ class Container {
             path: `/containers/${this.id}/stats?`,
             method: 'GET',
             options: opts,
-            isStream: true,
+            isStream: !!opts.stream,
             statusCodes: {
                 200: true,
                 404: 'no such container',


### PR DESCRIPTION
Currently you can not call the container.stats function and specify that you dont want to stream the results. This simple change uses the same method used in other functions for the container lib.

API reference: https://docs.docker.com/engine/api/v1.40/#operation/ContainerStats