### PR TITLE
Revert "Allow non streaming call to container.stats"

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -444,7 +444,7 @@ class Container {
             path: `/containers/${this.id}/stats?`,
             method: 'GET',
             options: opts,
-            isStream: !!opts.stream,
+            isStream: true,
             statusCodes: {
                 200: true,
                 404: 'no such container',


### PR DESCRIPTION
Reverts AgustinCB/docker-api#65

The change breaks the existing interface. Reverting. Will implement the change without breaking existing calls.